### PR TITLE
socials: Attempt to collapse to just icon

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -381,29 +381,39 @@ a {
 	align-items: center;
 	border-radius: 4px;
 	cursor: pointer;
-	transition: background 0.1s ease-in-out;
+	max-width: 48px;
+	transition: background 0.1s ease-in-out, max-width 0.1s linear;
 }
 
 .social:hover, .social:focus {
+	max-width: 300px;
 	background: var(--text-colour);
 	color: var(--background-colour);
 }
 
 .social p {
+	text-wrap: nowrap;
 	font-weight: bold;
 	background: none;
 	margin: 0;
+	overflow: hidden;
+	color: var(--background-colour);
 }
 
 .social svg {
 	margin-right: 16px;
 	width: 32px;
 	height: 32px;
+	min-width: 32px;
+	min-height: 32px;
 }
 
 .social p, .social svg {
-	color: var(--text-colour);
 	transition: color 0.1s ease-in-out;
+}
+
+.social svg {
+	color: var(--text-colour);
 }
 
 .social:hover p, .social:hover svg,


### PR DESCRIPTION
Resolves #33 

This doesn't seem to be really possible without significant workarounds though. In this PR, I'm using the `max-height` workaround, but that's not great as the timings vary wildly depending on which social we're interacting with.

The other issue is how to handle wrapping for this on smaller displays. At least on PC, where what you hover depends on what's currently under your cursor, even if it's in the middle of an animation, this kind of breaks down.

Here is an article with a bunch of techniques: https://css-tricks.com/using-css-transitions-auto-dimensions/